### PR TITLE
26.5.7 updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ on:
       - main
 
 env:
-  # Version 26.5.6
+  # Version 26.5.7
   VERSION_MAJOR: 26
   VERSION_SUBMAJOR: 5
-  VERSION_MINOR: 6
+  VERSION_MINOR: 7
 
 jobs:
   release-public:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/phasetwo/keycloak-crdb:26.5.6 AS builder
+FROM quay.io/phasetwo/keycloak-crdb:26.5.7 AS builder
 
 ENV KC_METRICS_ENABLED=true
 ENV KC_HEALTH_ENABLED=true
@@ -17,7 +17,7 @@ COPY ./libs/bundle/target/bundle*/*.jar /opt/keycloak/providers/
 
 RUN /opt/keycloak/bin/kc.sh --verbose build --spi-email-template-provider=freemarker-plus-mustache --spi-email-template-freemarker-plus-mustache-enabled=true --spi-theme-cache-themes=false
 
-FROM quay.io/phasetwo/keycloak-crdb:26.5.6
+FROM quay.io/phasetwo/keycloak-crdb:26.5.7
 
 #USER root
 # remediation for vulnerabilities

--- a/cluster/p2-entrypoint.sh
+++ b/cluster/p2-entrypoint.sh
@@ -18,4 +18,4 @@ fi
 # run the keycloak entrypoint with the given params
 RUN_OPTS="$@"
 echo "Running Keycloak with kc.sh $RUN_OPTS"
-/opt/keycloak/bin/kc.sh $RUN_OPTS
+exec /opt/keycloak/bin/kc.sh $RUN_OPTS

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -35,13 +35,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
     <main.java.package>io.phasetwo.containers</main.java.package>
-    <keycloak.version>26.5.6</keycloak.version>
-    <keycloak-events.version>0.51</keycloak-events.version>
-    <keycloak-magic-link.version>0.57</keycloak-magic-link.version>
-    <keycloak-orgs.version>0.142</keycloak-orgs.version>
+    <keycloak.version>26.5.7</keycloak.version>
+    <keycloak-events.version>0.53</keycloak-events.version>
+    <keycloak-magic-link.version>0.61</keycloak-magic-link.version>
+    <keycloak-orgs.version>0.144</keycloak-orgs.version>
     <keycloak-themes.version>0.51</keycloak-themes.version>
-    <phasetwo-admin-portal.version>0.51</phasetwo-admin-portal.version>
-    <phasetwo-idp-wizard.version>0.41</phasetwo-idp-wizard.version>
+    <phasetwo-admin-portal.version>0.55</phasetwo-admin-portal.version>
+    <phasetwo-idp-wizard.version>0.44</phasetwo-idp-wizard.version>
     <auto-service.version>1.1.1</auto-service.version>
     <guava.version>33.0.0-jre</guava.version>
     <lombok.version>1.18.42</lombok.version>


### PR DESCRIPTION
- version bump to 26.5.7. 
- update extension dependencies. 
- added exec (thanks gusto!) to our wrapper script for the cluster entrypoint.