### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,20 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: adopt
       - name: Build with Maven
         run: cd libs/ && mvn -U --batch-mode package && cd ../
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -43,7 +43,7 @@ jobs:
           echo "VERSION_TS=$TS" >> $GITHUB_ENV
           echo "VERSION_TAG=$VERSION_MAJOR.$VERSION_SUBMAJOR.$VERSION_MINOR.$TS" >> $GITHUB_ENV
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -55,7 +55,7 @@ jobs:
             quay.io/phasetwo/phasetwo-keycloak:${{ env.VERSION_MAJOR }}.${{ env.VERSION_SUBMAJOR }}.${{ env.VERSION_MINOR }}
             quay.io/phasetwo/phasetwo-keycloak:${{ env.VERSION_MAJOR }}.${{ env.VERSION_SUBMAJOR }}.${{ env.VERSION_MINOR }}.${{ env.VERSION_TS }}
       - name: Build cluster distribution and push to quay
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: "cluster/"
           file: "cluster/Dockerfile"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: adopt
       - name: Build with Maven
         run: cd libs/ && mvn -U --batch-mode package && cd ../
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Verify that Dockerfile builds
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           outputs: type=cacheonly


### PR DESCRIPTION
Upgrades deprecated Node.js 20 actions ahead of the June 2026 forced migration to Node.js 24:
  │           Action           │ Old │ New │                         
  ├────────────────────────────┼─────┼─────┤                         
  │ actions/checkout           │ v3  │ v6  │                         
  ├────────────────────────────┼─────┼─────┤                         
  │ actions/setup-java         │ v3    │ v5  │                       
  ├────────────────────────────┼───────┼─────┤                       
  │ docker/setup-qemu-action   │ v2    │ v4  │                     
  ├────────────────────────────┼───────┼─────┤
  │ docker/setup-buildx-action │ v2    │ v4  │
  ├────────────────────────────┼───────┼─────┤                       
  │ docker/login-action        │ v2    │ v4  │
  ├────────────────────────────┼───────┼─────┤                       
  │ docker/build-push-action   │ v3/v4 │ v7 