### PR TITLE
fix(security-scan): pre-pull image with retries to survive registry flakes

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,17 +27,45 @@ jobs:
       - name: Checkout (for openvex.json)
         uses: actions/checkout@v6
 
+      # Pre-pull each arch into the local docker daemon with retries. Trivy
+      # otherwise re-resolves the remote manifest on every scan step, so a
+      # single transient quay.io 5xx (e.g. run 26743161730 hit a 504) takes
+      # down the whole job. Pulling once with retry, tagging per-arch, and
+      # then pointing Trivy at the local tags eliminates the remote round-
+      # trips and gives us a survivable backoff window.
+      - name: Pull image per arch (with retries)
+        run: |
+          set -euo pipefail
+          pull_with_retry() {
+            local platform="$1" tag="$2" n=5 delay=20
+            for i in $(seq 1 $n); do
+              echo "::group::docker pull $platform (attempt $i/$n)"
+              if docker pull --platform "$platform" "$IMAGE"; then
+                docker tag "$IMAGE" "$tag"
+                echo "::endgroup::"
+                echo "✓ pulled $platform → $tag"
+                return 0
+              fi
+              echo "::endgroup::"
+              [ "$i" -lt "$n" ] && sleep "$delay"
+            done
+            echo "::error::Failed to pull $IMAGE for $platform after $n attempts"
+            return 1
+          }
+          pull_with_retry linux/amd64 scan-target:amd64
+          pull_with_retry linux/arm64 scan-target:arm64
+          docker image ls scan-target
+
       # OS-package scan, per arch — these are the CVEs a Wolfi rebuild can
       # actually fix, so this is the input to the rebuild-trigger decision.
-      # The action wrapper has no `vex` or `platform` inputs; both are
-      # passed via the Trivy CLI's TRIVY_<FLAG> env-var convention.
+      # The action wrapper has no `vex` input, so it's passed via the Trivy
+      # CLI's TRIVY_<FLAG> env-var convention.
       - name: Trivy — OS scan (linux/amd64)
         uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_VEX: openvex.json
-          TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ env.IMAGE }}
+          image-ref: scan-target:amd64
           format: json
           output: trivy-os-amd64.json
           severity: HIGH,CRITICAL
@@ -49,9 +77,8 @@ jobs:
         uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_VEX: openvex.json
-          TRIVY_PLATFORM: linux/arm64
         with:
-          image-ref: ${{ env.IMAGE }}
+          image-ref: scan-target:arm64
           format: json
           output: trivy-os-arm64.json
           severity: HIGH,CRITICAL
@@ -67,9 +94,8 @@ jobs:
         uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_VEX: openvex.json
-          TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ env.IMAGE }}
+          image-ref: scan-target:amd64
           format: json
           output: trivy-libs.json
           severity: HIGH,CRITICAL


### PR DESCRIPTION
## Summary

- The daily security scan failed on [run 26743161730](https://github.com/p2-inc/phasetwo-containers/actions/runs/26743161730) with a transient `504 Gateway Timeout` from quay.io. Trivy was scanning the published image over the remote path, so every scan step independently re-resolved the manifest — a single Quay flake took the whole job down.
- This PR pre-pulls the image into the local docker daemon once per arch (with 5× retry / 20 s backoff), tags the results as `scan-target:amd64` / `scan-target:arm64`, and points the three Trivy steps at the local tags. `TRIVY_PLATFORM` env vars are dropped because each local tag is already arch-specific.

The existing triage / artifact-upload / dispatch logic is untouched.

### Failure trace (from the original run)

```
FATAL  unable to find the specified image "quay.io/phasetwo/phasetwo-keycloak:latest"
    in ["docker" "containerd" "podman" "remote"]: 4 errors occurred:
  * docker:     No such image (we never pulled it locally)
  * containerd: socket permission denied
  * podman:     no socket
  * remote:     GET https://quay.io/v2/: unexpected status code 504 Gateway Timeout  ← root cause
```

## Test plan

- [x] `docker manifest inspect quay.io/phasetwo/phasetwo-keycloak:latest` confirms both `linux/amd64` and `linux/arm64` manifests exist
- [x] Ran the `pull_with_retry` helper locally against `linux/amd64`; resulting local tag reports `arch=amd64` via `docker image inspect`
- [x] `ruby -ryaml YAML.load_file` parses the workflow cleanly
- [ ] Trigger the workflow via **Run workflow** on this branch and confirm the pull-with-retry step succeeds and Trivy reads from the local daemon (no `remote error` in the failure mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)