### PR TITLE
bump libs to keycloak-orgs 0.165 + keycloak-themes 0.66; add host-m2 build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,40 @@
 # syntax=docker/dockerfile:1.7
 
 # ---------------------------------------------------------------------------
+# Default named context: empty layer that satisfies the `from=host-m2` bind
+# mount below when no `--build-context host-m2=...` flag is supplied (CI).
+#
+# To test against a SNAPSHOT in your host's ~/.m2, override the context with
+# a directory whose layout mirrors ~/.m2 (i.e. contains a `repository/`
+# subdir):
+#
+#     docker buildx build --build-context host-m2=$HOME/.m2 .
+#
+# BuildKit copies the entire host context into its filesystem before the
+# build runs, so a large ~/.m2 (multiple GB) can be slow and may exhaust
+# Docker's disk. For faster local testing, stage just the SNAPSHOTs you
+# need:
+#
+#     mkdir -p /tmp/scim-m2/repository/io/phasetwo
+#     cp -r ~/.m2/repository/io/phasetwo/keycloak \
+#           /tmp/scim-m2/repository/io/phasetwo/
+#     docker buildx build --build-context host-m2=/tmp/scim-m2 .
+#
+# ---------------------------------------------------------------------------
+FROM scratch AS host-m2
+
+# ---------------------------------------------------------------------------
 # Stage 1: build the extension/provider jars from libs/ with Maven.
 #
 # Runs on the native BUILDPLATFORM (jars are architecture-independent) so
 # multi-arch builds are not slowed down by qemu emulation of the JVM. Uses
 # a BuildKit cache mount for ~/.m2 to keep incremental rebuilds fast.
+#
+# When `host-m2` is overridden via `--build-context host-m2=$HOME/.m2`, the
+# host repository is overlaid onto the build's m2 cache with `cp -rf`,
+# so locally-installed SNAPSHOTs always win over whatever is in the cache
+# (essential for iterating on a SNAPSHOT: `cp -rn` would leave a stale
+# previous build of the SNAPSHOT in the cache forever).
 # ---------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-21 AS libs-builder
 
@@ -18,12 +47,22 @@ COPY libs/internal/pom.xml ./internal/pom.xml
 COPY libs/bundle/pom.xml ./bundle/pom.xml
 
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
+    --mount=type=bind,from=host-m2,target=/host-m2,readonly \
+    if [ -d /host-m2/repository ]; then \
+        mkdir -p /root/.m2/repository && \
+        cp -rf /host-m2/repository/. /root/.m2/repository/ 2>/dev/null || true; \
+    fi && \
     mvn -B -e --strict-checksums -ntp \
         -pl . -am dependency:go-offline -DskipTests || true
 
 COPY libs/ ./
 
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
+    --mount=type=bind,from=host-m2,target=/host-m2,readonly \
+    if [ -d /host-m2/repository ]; then \
+        mkdir -p /root/.m2/repository && \
+        cp -rf /host-m2/repository/. /root/.m2/repository/ 2>/dev/null || true; \
+    fi && \
     mvn -B -e --strict-checksums -ntp clean package -DskipTests
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -70,6 +70,52 @@ The build uses three stages:
    OpenJDK 21 JRE + bash + CA bundle, and runs as a non-root user. See
    the *Hardening* section below.
 
+### Building against a local SNAPSHOT (`host-m2`)
+
+If you are iterating on a Phase Two extension (`keycloak-orgs`,
+`keycloak-themes`, etc.) and have installed a SNAPSHOT to your host
+`~/.m2`, you can expose that repository to the in-Dockerfile Maven
+build via the optional `host-m2` named build context. With no override,
+the Dockerfile resolves `host-m2` to an inline empty `FROM scratch`
+stage, so CI behavior is unchanged.
+
+**With `docker build`:**
+
+```bash
+# Default — host-m2 is empty, everything comes from Maven Central
+docker buildx build .
+
+# Override — overlay your host's m2 repo onto the build cache
+docker buildx build --build-context host-m2=$HOME/.m2 .
+```
+
+**With `docker compose`:** the compose file picks the override up from
+the `HOST_M2` env var:
+
+```bash
+HOST_M2=$HOME/.m2 docker compose build keycloak
+```
+
+BuildKit transfers the entire `host-m2` context into its filesystem
+before the build runs, so a large `~/.m2` (multiple GB) can be slow
+and may exhaust Docker Desktop's disk. For faster iteration, stage
+only the SNAPSHOTs you need:
+
+```bash
+mkdir -p /tmp/scoped-m2/repository/io/phasetwo/keycloak
+cp -r ~/.m2/repository/io/phasetwo/keycloak/keycloak-orgs \
+      /tmp/scoped-m2/repository/io/phasetwo/keycloak/
+
+HOST_M2=/tmp/scoped-m2 docker compose build keycloak
+# or:
+docker buildx build --build-context host-m2=/tmp/scoped-m2 .
+```
+
+The Dockerfile uses `cp -rf` to overlay `host-m2` onto its m2 cache,
+so a freshly-installed SNAPSHOT on the host always wins over a stale
+copy in the BuildKit cache mount. Released artifacts are unaffected
+because the overlay only contains what's in your staged directory.
+
 ## Local testing
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,19 @@ services:
     ports:
       - 26257:26257
   keycloak:
-    build: .
+    build:
+      context: .
+      # Override `host-m2` to expose a host Maven repository to the libs
+      # build stage (see Dockerfile). Default is an empty scratch image, so
+      # CI builds behave the same as `FROM scratch AS host-m2` in the
+      # Dockerfile. To pull in locally-installed SNAPSHOTs, set HOST_M2 to a
+      # directory whose layout mirrors ~/.m2 (contains `repository/`):
+      #   HOST_M2=$HOME/.m2 docker compose build keycloak
+      # Note: BuildKit transfers the entire HOST_M2 directory before
+      # running the build, so for large repos prefer staging a small subset
+      # (e.g. just io/phasetwo/).
+      additional_contexts:
+        - "host-m2=${HOST_M2:-docker-image://scratch}"
     environment:
       KC_DB: cockroach
       KC_HTTP_RELATIVE_PATH: /auth

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -36,11 +36,11 @@
     <java.version>21</java.version>
     <main.java.package>io.phasetwo.containers</main.java.package>
     <keycloak.version>26.6.2</keycloak.version>
-    <keycloak-events.version>0.56</keycloak-events.version>
+    <keycloak-events.version>0.57</keycloak-events.version>
     <keycloak-magic-link.version>0.70</keycloak-magic-link.version>
-    <keycloak-orgs.version>0.164</keycloak-orgs.version>
-    <keycloak-scim-server.version>1.5.0.3</keycloak-scim-server.version>
-    <keycloak-themes.version>0.65</keycloak-themes.version>
+    <keycloak-orgs.version>0.165</keycloak-orgs.version>
+    <keycloak-scim-server.version>1.5.0.4</keycloak-scim-server.version>
+    <keycloak-themes.version>0.66</keycloak-themes.version>
     <phasetwo-admin-portal.version>0.58</phasetwo-admin-portal.version>
     <phasetwo-idp-wizard.version>0.48</phasetwo-idp-wizard.version>
     <auto-service.version>1.1.1</auto-service.version>


### PR DESCRIPTION
## Summary

Two related changes bundled together so they ship in the same image rebuild:

1. **Pick up the upstream permission/UI fixes** by bumping `libs/pom.xml`:
   - `keycloak-orgs` 0.164 → **0.165** ([p2-inc/keycloak-orgs#469](https://github.com/p2-inc/keycloak-orgs/pull/469) — fixes the 401 on org admin endpoints under DPoP-bound tokens and on the master realm)
   - `keycloak-themes` 0.65 → **0.66** ([p2-inc/keycloak-themes#92](https://github.com/p2-inc/keycloak-themes/pull/92) — admin UI no longer masks real server errors with "Response body is already used")
   - `keycloak-events` 0.56 → 0.57
   - `keycloak-scim-server` 1.5.0.3 → 1.5.0.4

2. **Build-time `host-m2` named context** for iterating on upstream SNAPSHOTs without round-tripping through Maven Central. This is the workflow that enabled the debug-and-fix loop behind #1.

## Why both in one PR

The two changes flow together: #1 fixes the bug visible to end users on master realm; #2 is the build-side capability that made fixing #1 practical and that we'll lean on for the next round of upstream iteration. Releasing the rebuild as a single image tag makes the operational story simple — pull the new tag, both fixes are in.

## host-m2 — what's new

### Motivation

When iterating on a SNAPSHOT of a phasetwo extension (`keycloak-orgs`, `keycloak-themes`, etc.) the previous build flow had no way to point the Dockerfile's inline mvn at a host-local jar. The BuildKit cache mount at `/root/.m2` lives inside Docker, so a `mvn install` on the host was invisible to the image build, forcing a round-trip through a published version for every test cycle.

### Dockerfile changes

- New `FROM scratch AS host-m2` stage at the top, acting as the default empty named context.
- Both `libs-builder` RUN steps gain `--mount=type=bind,from=host-m2,target=/host-m2,readonly` and overlay `/host-m2/repository/` onto `/root/.m2/repository/` with `cp -rf` (force-overwrite, **not** `cp -rn`) so a freshly-installed SNAPSHOT on the host always wins over a stale copy in the cache mount. Guarded by `if [ -d /host-m2/repository ]` so the empty default short-circuits.
- Inline comment block documents the override commands and the SNAPSHOT-staging tip (large `~/.m2` directories can be slow — stage a small subset).

### docker-compose.yml changes

- Expand `build: .` to long form with:
  ```yaml
  build:
    context: .
    additional_contexts:
      - "host-m2=${HOST_M2:-docker-image://scratch}"
  ```
  Default value mirrors the Dockerfile's inline default. Override via `HOST_M2=$HOME/.m2 docker compose build keycloak`.

### README

A new "Building against a local SNAPSHOT (`host-m2`)" section under **Building** documents the override commands for both `docker buildx build` and `docker compose build`, plus the scoped-staging recipe.

## How CI sees this

`release.yml` and `verify.yml` both use `docker/build-push-action@v7` with `context: .` and **no** `additional-contexts` / `build-contexts` input. With no override, BuildKit resolves `from=host-m2` to the inline `FROM scratch AS host-m2` stage in the Dockerfile, the bind mount sees an empty directory, the `if [ -d /host-m2/repository ]` guard short-circuits, and `mvn` runs exactly as before. **No workflow changes required.**

Verified locally after `docker buildx prune -af` that the full image builds end-to-end with no host-m2 override — same behavior CI will see.

`security-scan.yml` only scans the published image; it doesn't build anything. Also unaffected.

## How to use host-m2 locally

| Scenario | Command |
|---|---|
| Default / CI | `docker compose build keycloak` (no env var) |
| Full host `~/.m2` (slow if large) | `HOST_M2=$HOME/.m2 docker compose build keycloak` |
| Scoped staging dir (recommended) | `HOST_M2=/tmp/scoped-m2 docker compose build keycloak` |

Scoped staging dir example:
```bash
mkdir -p /tmp/scoped-m2/repository/io/phasetwo/keycloak
cp -r ~/.m2/repository/io/phasetwo/keycloak/keycloak-orgs \
      /tmp/scoped-m2/repository/io/phasetwo/keycloak/
HOST_M2=/tmp/scoped-m2 docker compose build keycloak
```

## Test plan

- [x] `docker buildx prune -af && docker buildx build .` succeeds with no `--build-context` flag (CI scenario, default scratch fallback).
- [x] `docker buildx build --target libs-builder --build-context host-m2=/tmp/scoped-m2 .` succeeds and picks up a staged local SNAPSHOT (verified during the keycloak-orgs fix work).
- [x] `mvn` resolves the new released versions (0.165 / 0.66 / 0.57 / 1.5.0.4) from Maven Central in the libs-builder stage.
- [ ] PR's `verify.yml` check (Trivy scan on a `cache-from: gha` build) passes.
- [ ] After merge, `release.yml` builds and pushes the multi-arch image to quay.io.
- [ ] On the new image: master-realm admin → **Organizations → Manage Settings** opens without 401; **Create Organization** succeeds.
