### PR TITLE
fix: restore commit hash in Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,15 @@ jobs:
           echo "VERSION_MINOR=$VERSION_MINOR" >> $GITHUB_ENV
           echo "VERSION_TS=$TS" >> $GITHUB_ENV
           echo "VERSION_TAG=$VERSION_MAJOR.$VERSION_SUBMAJOR.$VERSION_MINOR.$TS" >> $GITHUB_ENV
+          echo "GIT_COMMIT=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
           tags: |
             quay.io/phasetwo/phasetwo-keycloak:latest
             quay.io/phasetwo/phasetwo-keycloak:${{ env.VERSION_MAJOR }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,8 @@ jobs:
           context: .
           platforms: linux/amd64
           load: true
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: phasetwo-keycloak:pr
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Compute short commit SHA
+        run: echo "GIT_COMMIT=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
+
       # Build single-arch and load into the local daemon so Trivy can scan
       # the actual layers this PR would produce.
       - name: Build image
@@ -24,7 +27,7 @@ jobs:
           platforms: linux/amd64
           load: true
           build-args: |
-            GIT_COMMIT=${{ github.sha }}
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
           tags: phasetwo-keycloak:pr
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,12 @@ FROM scratch AS host-m2
 # ---------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-21 AS libs-builder
 
+# Git commit SHA injected at build time. The buildnumber-maven-plugin inside
+# libs/internal/pom.xml normally reads this from .git, but .git is not
+# available inside the Docker build context. Passing it here lets the
+# fizzed-versionizer plugin stamp the correct commit into the Version class.
+ARG GIT_COMMIT=unknown
+
 WORKDIR /build
 
 # Bring in just the poms first so dependency resolution layer can be cached
@@ -63,7 +69,8 @@ RUN --mount=type=cache,target=/root/.m2,sharing=locked \
         mkdir -p /root/.m2/repository && \
         cp -rf /host-m2/repository/. /root/.m2/repository/ 2>/dev/null || true; \
     fi && \
-    mvn -B -e --strict-checksums -ntp clean package -DskipTests
+    mvn -B -e --strict-checksums -ntp clean package -DskipTests \
+        -DbuildNumber="${GIT_COMMIT}"
 
 # ---------------------------------------------------------------------------
 # Stage 2: Keycloak builder. Stages the providers and runs `kc.sh build` so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
   keycloak:
     build:
       context: .
+      args:
+        GIT_COMMIT: "${GIT_COMMIT:-unknown}"
       # Override `host-m2` to expose a host Maven repository to the libs
       # build stage (see Dockerfile). Default is an empty scratch image, so
       # CI builds behave the same as `FROM scratch AS host-m2` in the


### PR DESCRIPTION
## Summary

- Fixes the `Commit: unknown` startup log regression introduced in #148 when the Maven build was moved inside a Docker multi-stage build
- The `buildnumber-maven-plugin` in `libs/internal/pom.xml` needs a `.git` directory to resolve the commit SHA, but only `libs/` is copied into the container
- Adds a `GIT_COMMIT` build arg to the Dockerfile and passes it to Maven via `-DbuildNumber`, which the `fizzed-versionizer-maven-plugin` uses to generate the `Version` class
- CI workflows (`release.yml`, `verify.yml`) and `docker-compose.yml` now supply the short 8-char SHA matching the plugin's `shortRevisionLength` config

Fixes #152

## Test plan

- [ ] Build the Docker image locally: `GIT_COMMIT=$(git rev-parse --short=8 HEAD) docker compose build keycloak`
- [ ] Start the container and verify the startup log shows the correct commit hash instead of `unknown`
- [ ] Verify CI passes on this PR (verify workflow injects the SHA)