### PR TITLE
Comment released version and downstream component PRs back on PRs

### DIFF
--- a/.github/scripts/ComponentDigest.java
+++ b/.github/scripts/ComponentDigest.java
@@ -1,0 +1,157 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS org.kohsuke:github-api:2.0-rc.6
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.kohsuke.github.GHCompare;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+
+/**
+ * Builds the "component updates in this PR" comment body for a
+ * phasetwo-containers PR that bumps libs/pom.xml component versions: the list
+ * of downstream PRs that shipped between the old and new version of each
+ * changed component.
+ *
+ * <p>This only computes and prints the comment body to stdout (or the literal
+ * {@link #NO_CHANGES} sentinel if no tracked component changed) — it never
+ * writes to GitHub. It's meant to run from a plain {@code pull_request}
+ * workflow, whose token is read-only for fork PRs; a separate
+ * {@code workflow_run}-triggered workflow with write access is responsible
+ * for actually posting the comment.
+ *
+ * <p>Usage: ComponentDigest.java <old-pom-path> <new-pom-path> <owner/repo>
+ * <base-sha> <head-sha>
+ */
+public class ComponentDigest {
+
+  static final String MARKER = "<!-- component-pr-digest -->";
+  static final String NO_CHANGES = "NO_CHANGES";
+
+  // property name in libs/pom.xml -> component's GitHub repo. Tags in that
+  // repo are expected to be "v<version>". Unknown properties are ignored.
+  static final Map<String, String> COMPONENT_REPOS =
+      Map.ofEntries(
+          Map.entry("keycloak-events.version", "p2-inc/keycloak-events"),
+          Map.entry("keycloak-magic-link.version", "p2-inc/keycloak-magic-link"),
+          Map.entry("keycloak-orgs.version", "p2-inc/keycloak-orgs"),
+          Map.entry("keycloak-scim-server.version", "p2-inc/keycloak-scim-server"),
+          Map.entry("keycloak-themes.version", "p2-inc/keycloak-themes"),
+          Map.entry("phasetwo-admin-portal.version", "p2-inc/phasetwo-admin-portal"),
+          Map.entry("phasetwo-idp-wizard.version", "p2-inc/idp-wizard"));
+
+  public static void main(String[] args) throws IOException {
+    if (args.length != 5) {
+      System.err.println(
+          "usage: ComponentDigest.java <old-pom> <new-pom> <owner/repo> <base-sha> <head-sha>");
+      System.exit(1);
+    }
+    String oldPom = Files.readString(Path.of(args[0]));
+    String newPom = Files.readString(Path.of(args[1]));
+    String thisRepo = args[2];
+    String baseSha = args[3];
+    String headSha = args[4];
+
+    GitHub gh = new GitHubBuilder().withOAuthToken(System.getenv("GITHUB_TOKEN")).build();
+
+    List<String> sections = new ArrayList<>();
+    for (Map.Entry<String, String> entry : COMPONENT_REPOS.entrySet()) {
+      String propertyKey = entry.getKey();
+      String repoName = entry.getValue();
+      String oldVersion = extractVersion(oldPom, propertyKey);
+      String newVersion = extractVersion(newPom, propertyKey);
+      if (oldVersion == null || newVersion == null || oldVersion.equals(newVersion)) {
+        continue;
+      }
+      sections.add(digestSection(gh, propertyKey, repoName, oldVersion, newVersion));
+    }
+
+    if (sections.isEmpty()) {
+      System.out.println(NO_CHANGES);
+      return;
+    }
+
+    String updatedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString();
+    String shortBase = baseSha.substring(0, Math.min(7, baseSha.length()));
+    String shortHead = headSha.substring(0, Math.min(7, headSha.length()));
+    String compareUrl =
+        String.format("https://github.com/%s/compare/%s...%s", thisRepo, baseSha, headSha);
+
+    StringBuilder body = new StringBuilder();
+    body.append(MARKER).append("\n");
+    body.append("## Component updates in this PR\n\n");
+    body.append(
+        String.format(
+            "_Auto-generated, updates on every push to this PR. Last updated %s from"
+                + " [`%s...%s`](%s)._%n%n",
+            updatedAt, shortBase, shortHead, compareUrl));
+    for (String section : sections) {
+      body.append(section).append("\n");
+    }
+
+    System.out.println(body);
+  }
+
+  static String extractVersion(String pom, String propertyKey) {
+    Pattern p =
+        Pattern.compile(
+            "<" + Pattern.quote(propertyKey) + ">([^<]*)</" + Pattern.quote(propertyKey) + ">");
+    Matcher m = p.matcher(pom);
+    return m.find() ? m.group(1).trim() : null;
+  }
+
+  static String digestSection(
+      GitHub gh, String propertyKey, String repoName, String oldVersion, String newVersion) {
+    String component = propertyKey.substring(0, propertyKey.length() - ".version".length());
+    String oldTag = "v" + oldVersion;
+    String newTag = "v" + newVersion;
+    String header =
+        String.format(
+            "### %s: `%s` → `%s` ([%s](https://github.com/%s))%n",
+            component, oldVersion, newVersion, repoName, repoName);
+
+    try {
+      GHRepository repo = gh.getRepository(repoName);
+      GHCompare compare = repo.getCompare(oldTag, newTag);
+
+      LinkedHashMap<Integer, GHPullRequest> prs = new LinkedHashMap<>();
+      for (GHCompare.Commit commit : compare.getCommits()) {
+        for (GHPullRequest pr : commit.listPullRequests()) {
+          prs.putIfAbsent(pr.getNumber(), pr);
+        }
+      }
+
+      if (prs.isEmpty()) {
+        return header
+            + String.format("- _no pull requests found; [compare](%s)_%n", compare.getHtmlUrl());
+      }
+
+      StringBuilder sb = new StringBuilder(header);
+      prs.values().stream()
+          .sorted(Comparator.comparingInt(GHPullRequest::getNumber))
+          .forEach(
+              pr ->
+                  sb.append(
+                      String.format(
+                          "- [#%d](%s) %s%n", pr.getNumber(), pr.getHtmlUrl(), pr.getTitle())));
+      return sb.toString();
+    } catch (IOException e) {
+      return header
+          + String.format(
+              "- _couldn't diff `%s...%s` (%s); see [compare](https://github.com/%s/compare/%s...%s)_%n",
+              oldTag, newTag, e.getMessage(), repoName, oldTag, newTag);
+    }
+  }
+}

--- a/.github/workflows/component-pr-digest-post.yml
+++ b/.github/workflows/component-pr-digest-post.yml
@@ -1,0 +1,78 @@
+name: Post component PR digest
+
+# Runs in the base repo's context (full permissions, real secrets) after
+# component-pr-digest.yml finishes, regardless of whether that run came from
+# a fork. See https://github.com/orgs/community/discussions/25220 for why
+# this two-workflow split is the safe way to comment on fork PRs.
+on:
+  workflow_run:
+    workflows: ["Component PR digest"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-context:
+    name: Acquire PR context
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    outputs:
+      PR_NUMBER: ${{ steps.set-pr-context.outputs.number }}
+    steps:
+      - name: Get PR context
+        id: set-pr-context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+            --json number \
+            --jq '"number=\(.number)"' \
+            >> "$GITHUB_OUTPUT"
+
+  comment:
+    name: Comment component digest on PR
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    needs: [pr-context]
+    steps:
+      - name: Download digest artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: component-pr-digest
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/digest
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.pr-context.outputs.PR_NUMBER }}
+        run: |
+          set -euo pipefail
+
+          BODY="$(cat "$GITHUB_WORKSPACE/digest/digest.md")"
+          if [ "$BODY" = "NO_CHANGES" ]; then
+            echo "No tracked component changes in this PR; nothing to comment."
+            exit 0
+          fi
+
+          MARKER="<!-- component-pr-digest -->"
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            | jq -r --arg m "$MARKER" '.[] | select(.body | startswith($m)) | .id' | head -n1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING_ID" -f body="$BODY"
+          else
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi

--- a/.github/workflows/component-pr-digest.yml
+++ b/.github/workflows/component-pr-digest.yml
@@ -1,0 +1,59 @@
+name: Component PR digest
+
+# Only computes the digest and uploads it as an artifact -- it never talks to
+# the PR itself. This is what makes it safe to run on PRs from forks: GitHub
+# forces GITHUB_TOKEN to be read-only for pull_request events from a fork, so
+# any attempt to comment here would just fail. Posting the comment is the job
+# of component-pr-digest-post.yml, which runs via workflow_run in the base
+# repo's context and has write access.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - libs/pom.xml
+
+permissions:
+  contents: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Extract old and new libs/pom.xml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/contents/libs/pom.xml?ref=${{ github.event.pull_request.base.sha }}" --jq .content | base64 -d > /tmp/old-pom.xml
+          gh api "repos/${{ github.repository }}/contents/libs/pom.xml?ref=${{ github.event.pull_request.head.sha }}" --jq .content | base64 -d > /tmp/new-pom.xml
+
+      - name: Install jbang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> "$GITHUB_PATH"
+
+      - name: Cache jbang dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.jbang
+          key: ${{ runner.os }}-jbang-component-digest
+
+      - name: Build component digest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jbang .github/scripts/ComponentDigest.java \
+            /tmp/old-pom.xml /tmp/new-pom.xml \
+            ${{ github.repository }} \
+            ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+            > digest.md
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: component-pr-digest
+          path: digest.md
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
   # against a freshly patched Wolfi base when OS-package CVEs are detected.
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   # Version 26.6.4
   VERSION_MAJOR: 26
@@ -72,6 +76,42 @@ jobs:
         env:
           TAG: v${{ env.VERSION_TAG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Comments the released image tag back on the PR that this commit came
+      # from, so a version-bump PR shows exactly what it shipped as.
+      # Skipped on manual workflow_dispatch reruns (e.g. the daily CVE-patch
+      # rebuild), which aren't tied to a newly merged PR.
+      - name: Comment released version on originating PR
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR associated with commit $COMMIT_SHA; skipping release comment."
+            exit 0
+          fi
+
+          MARKER="<!-- release-version-comment -->"
+          BODY="$MARKER
+          This shipped in \`$VERSION_TAG\`:
+
+          \`\`\`
+          quay.io/phasetwo/phasetwo-keycloak:$VERSION_TAG
+          \`\`\`"
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            | jq -r --arg m "$MARKER" '.[] | select(.body | startswith($m)) | .id' | head -n1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING_ID" -f body="$BODY"
+          else
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi
 
       # Post-release Trivy scan against the just-pushed image. This is a
       # record of what shipped — non-gating (the image is already public)


### PR DESCRIPTION
## Summary
- Extends `release.yml` to comment the released image tag (e.g. `26.6.4.<timestamp>`) back on the PR whose merge triggered the release, so a version-bump PR shows exactly which image it shipped in.
- Adds a component PR digest: PRs that bump a component version in `libs/pom.xml` get a comment listing the downstream PRs merged into each changed component between the old and new version, grouped by component.
- The digest is split into two workflows (`component-pr-digest.yml` + `component-pr-digest-post.yml`) so it works safely for PRs opened from forks: GitHub forces `GITHUB_TOKEN` to read-only for `pull_request` events from a fork, so the first workflow only computes the digest and uploads it as an artifact; the second runs via `workflow_run` in this repo's own context (real write permissions) and posts/updates the comment.

## Test plan
- [x] Dry-ran the digest logic locally against real historical PRs (e.g. #148) using the actual GitHub API — confirmed correct per-component grouping and PR attribution, including across a fork boundary (`keycloak-scim-server`).
- [x] Dry-ran the release-comment bash logic locally against a real historical release commit/PR (#154) — confirmed correct PR lookup and comment body.
- [ ] Live end-to-end validation once merged — see #157, a real version-bump PR stacked on this branch as a live test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)