### PR TITLE
Bump keycloak-events to 0.62 and keycloak-orgs to 0.168

### DIFF
--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -36,9 +36,9 @@
     <java.version>21</java.version>
     <main.java.package>io.phasetwo.containers</main.java.package>
     <keycloak.version>26.6.4</keycloak.version>
-    <keycloak-events.version>0.61</keycloak-events.version>
+    <keycloak-events.version>0.62</keycloak-events.version>
     <keycloak-magic-link.version>0.72</keycloak-magic-link.version>
-    <keycloak-orgs.version>0.167</keycloak-orgs.version>
+    <keycloak-orgs.version>0.168</keycloak-orgs.version>
     <keycloak-scim-server.version>1.6.0.6</keycloak-scim-server.version>
     <keycloak-themes.version>0.69</keycloak-themes.version>
     <phasetwo-admin-portal.version>0.59</phasetwo-admin-portal.version>


### PR DESCRIPTION
## Summary
- Bumps \`keycloak-events.version\` 0.61 → 0.62 and \`keycloak-orgs.version\` 0.167 → 0.168 in \`libs/pom.xml\`.

Branched from and depends on #156 — this is also meant as a live test case for the component-PR-digest workflow introduced there. Since #156 hasn't merged yet, this PR's diff/commit list currently includes #156's commits too; that'll clear up once #156 lands and this gets rebased onto \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)