### PR TITLE
Update keycloak-themes.version to 0.70

### DIFF
--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -40,7 +40,7 @@
     <keycloak-magic-link.version>0.72</keycloak-magic-link.version>
     <keycloak-orgs.version>0.170</keycloak-orgs.version>
     <keycloak-scim-server.version>1.6.0.6</keycloak-scim-server.version>
-    <keycloak-themes.version>0.69</keycloak-themes.version>
+    <keycloak-themes.version>0.70</keycloak-themes.version>
     <phasetwo-admin-portal.version>0.59</phasetwo-admin-portal.version>
     <phasetwo-idp-wizard.version>0.49</phasetwo-idp-wizard.version>
     <auto-service.version>1.1.1</auto-service.version>


### PR DESCRIPTION
Bumps the bundled `keycloak-themes` dependency from 0.69 to 0.70 so the released container image picks up the latest theme release.

- `libs/pom.xml`: `keycloak-themes.version` 0.69 → 0.70