### PR TITLE
bump to 26.6.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ permissions:
   pull-requests: write
 
 env:
-  # Version 26.6.5
+  # Version 26.6.6
   VERSION_MAJOR: 26
   VERSION_SUBMAJOR: 6
-  VERSION_MINOR: 5
+  VERSION_MINOR: 6
 
 jobs:
   release-public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       KC_PROXY_HEADERS: 'xforwarded'
       KC_SPI_EVENTS_STORE_PROVIDER: ext-event-mdc-logger-store
       KC_SPI_EVENTS_STORE_EXT_EVENT_MDC_LOGGER_STORE_USE_JPA: 'true'
+      EXT_EVENT_MDC_LOGGER_ENABLED: 'true'
       KC_TRANSACTION_JTA_ENABLED: 'false'
       KC_TRANSACTION_XA_ENABLED: 'false'
     ports:

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
     <main.java.package>io.phasetwo.containers</main.java.package>
-    <keycloak.version>26.6.5</keycloak.version>
+    <keycloak.version>26.6.6</keycloak.version>
     <keycloak-events.version>0.62</keycloak-events.version>
     <keycloak-magic-link.version>0.75</keycloak-magic-link.version>
     <keycloak-orgs.version>0.173</keycloak-orgs.version>


### PR DESCRIPTION
Bumps Keycloak to **26.6.6** — `keycloak.version` in `libs/pom.xml` and `VERSION_MINOR` in `release.yml`.

Like 26.6.5, this tag is not published (Maven Central 404s for `keycloak-common:26.6.6`), so it is built from source from the `p2-inc/keycloak` `26.6.6_crdb` branch by `scripts/build-keycloak.sh`. No build changes were needed — the bump is two lines.

## Validation

Built locally on arm64 (`26.6.6_crdb` @ `666021b2`, full 136-module reactor on JDK 21, 2m17s including the branch fetch):

- **Distribution vs. the published `quay.io/phasetwo/keycloak-crdb:26.6.6`** — identical file sets except the one host-selected `brotli4j.native-*` jar (`osx-aarch64` on a Mac vs `linux-x86_64` from a Linux builder; see the README's *Equivalence with the `keycloak-crdb` image* section). Of 472 jars: 435 byte-identical by per-entry CRC, 35 differing only in build metadata (`MANIFEST.MF`, `keycloak-version.properties`), and 2 — `generated-bytecode.jar` / `transformed-bytecode.jar` — which are Quarkus augmentation output that stage 2's `kc.sh build` regenerates anyway.
- **Staged build context** — 177 jars, all `26.6.6`, `Build-Jdk-Spec: 21`, no `26.6.5` leftovers. Re-running the script is a 0.7s no-op.
- **Image** — builds clean; starts as `Keycloak 26.6.6 on JVM (powered by Quarkus 3.33.3.1) started in 1.570s`, `/health/ready` in ~6s, `/health/live` 200, admin console 200, OIDC discovery 200, orgs extension 401 (route mounted), 30 Phase Two extension init lines, zero `ERROR` lines. CockroachDB JDBC driver present in `providers/`.
- **CockroachDB** — started against `cockroachdb/cockroach:v23.2.23` with `KC_DB=cockroach`: Liquibase migrated 107 tables, master realm 200, orgs 401.

## Noted separately (not from this bump)

`docker-compose.yml` sets `KC_SPI_EVENTS_STORE_PROVIDER=ext-event-mdc-logger-store` but not `EXT_EVENT_MDC_LOGGER_ENABLED=true`, which `cluster/Dockerfile` does set alongside it. Without it, startup fails with `Failed to find provider ext-event-mdc-logger-store for eventsStore`. Confirmed pre-existing: the **published** `phasetwo-keycloak:26.6.5` image fails identically with the same env, and the compose file is unchanged on `main`. Left out of this PR to keep it to the version bump.
