### PR TITLE
build(libs): keycloak-themes 0.72 -> 0.75, admin-portal 0.59 -> 0.60

### DIFF
--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -40,8 +40,8 @@
     <keycloak-magic-link.version>0.75</keycloak-magic-link.version>
     <keycloak-orgs.version>0.173</keycloak-orgs.version>
     <keycloak-scim-server.version>1.7.0.1</keycloak-scim-server.version>
-    <keycloak-themes.version>0.72</keycloak-themes.version>
-    <phasetwo-admin-portal.version>0.59</phasetwo-admin-portal.version>
+    <keycloak-themes.version>0.75</keycloak-themes.version>
+    <phasetwo-admin-portal.version>0.60</phasetwo-admin-portal.version>
     <phasetwo-idp-wizard.version>0.49</phasetwo-idp-wizard.version>
     <auto-service.version>1.1.1</auto-service.version>
     <guava.version>33.0.0-jre</guava.version>


### PR DESCRIPTION
Brings the shared brand tokens into the image.

These are the pins that **actually reach a running cluster** — `libs/bundle` is copied into `/opt/keycloak/providers/`. (The `keycloak-themes.version` property in phasetwo-keycloak's own pom is `scope=provided` and ships nothing; phasetwo-keycloak#572 was closed for that reason, thanks @xgp.)

## What comes in

**keycloak-themes 0.72 → 0.75**
- **0.73** — `login.css` resolves a realm's `_providerConfig.assets.theme.v2.*` attributes and expands them into the full shadcn variable set as `:root`/`.dark`, after the legacy `--p2-login-*` block and before custom CSS. Includes the fix keeping a custom brand colour from reverting to the default in dark mode.
- **0.74** — the phasetwo-ui admin **Styles → Login** panel gains inputs for those tokens (it previously wrote only the legacy colours, which the resolver now shadows).
- **0.75** — the email template reads the tokens instead of hardcoded colours.

**phasetwo-admin-portal 0.59 → 0.60** — the portal moves onto the same `assets.theme.v2.*` namespace, folding its `cta` token into `primary`.

## Compatibility

A realm that sets no `theme.v2.*` attribute renders exactly as it does today: every surface falls back to the legacy `assets.login.*Color` / `assets.portal.*Color` keys and then to its built-in defaults. The legacy `--p2-login-*` block is still emitted, so the PatternFly `attributes` / `attributes-v2` themes are unaffected.

Email is the one place that deliberately does *not* fall back to resolved defaults — only tokens a realm has explicitly set are passed through, because the email template's own defaults differ from the login palette (a near-black button rather than the login blue). Unbranded email is byte-identical.

## Checks

`dependency:tree` on `libs` resolves `io.phasetwo.keycloak:keycloak-themes:jar:0.75` and `io.phasetwo:phasetwo-admin-portal:jar:0.60`, and the bundle assembles. Both confirmed present on Maven Central (0.75 had a short sync delay after tagging — waited for it rather than pushing a bump that would fail the build).

## After this

The `FROM` tag in `phasetwo-keycloak/docker/Dockerfile` needs pointing at the resulting base image, then per-customer `image.tag` in apps-deploy.