### PR TITLE
ci(release): attach SBOM and provenance attestations to pushed images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,13 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          # Attach a CycloneDX SBOM and SLSA provenance to the pushed image.
+          # BuildKit generates these from the final image, so they cover the
+          # prebuilt jars in libs/ext/ and the Wolfi base packages -- neither of
+          # which appears in libs/pom.xml. Retrievable per digest with
+          # `docker buildx imagetools inspect --format '{{ json .SBOM }}' <ref>`.
+          sbom: true
+          provenance: true
           build-args: |
             GIT_COMMIT=${{ env.GIT_COMMIT }}
           build-contexts: |
@@ -75,6 +82,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: true
           tags: |
             quay.io/phasetwo/phasetwo-cluster:latest
             quay.io/phasetwo/phasetwo-cluster:${{ env.VERSION_MAJOR }}


### PR DESCRIPTION
## What

Turns on BuildKit's `sbom` and `provenance` exporters for both `docker/build-push-action` steps in `release.yml`, so every released `phasetwo-keycloak` and `phasetwo-cluster` image carries an **SPDX SBOM** and **SLSA provenance** as OCI attestations in Quay.

Nine lines, no new tooling, no new actions.

## Why

Enterprise procurement asks for a software bill of materials as a matter of course now, and we are picking up a contractual commitment to provide a component inventory with licenses on request. Two design choices worth stating:

**Why BuildKit rather than GitHub's dependency graph.** Three components ship as prebuilt jars in `libs/ext/` — `apple-identity-provider`, `phasetwo-admin-ui` and `keycloak-rest-provider` — and are **not** `libs/pom.xml` dependencies. Any SBOM derived from the Maven manifests silently omits them, along with every OS package from the Wolfi base. BuildKit inspects the finished image, so it does not. This is not hypothetical: identifying those three jars recently required reading their embedded Maven metadata, because neither the pom nor the README lists all of them.

**Why per-build rather than on demand.** The attestation is stored alongside the image and remains retrievable by digest indefinitely. That means we can produce the SBOM for a version a customer was running months ago — which is when the question actually gets asked, during an audit or after an incident. A locally generated file has no provenance, and `upload-artifact` expires after 90 days.

Trivy already runs post-push here and could emit an SBOM too, but it produces a loose file rather than something attached to the image, so this is the better primitive. The two are complementary if we later want an emailable copy.

## Verifying

After the next release, per platform:

```sh
docker buildx imagetools inspect quay.io/phasetwo/phasetwo-keycloak:<tag> \
  --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > sbom-amd64.json

jq '.packages | length' sbom-amd64.json
```

Provenance:

```sh
docker buildx imagetools inspect quay.io/phasetwo/phasetwo-keycloak:<tag> \
  --format '{{ json (index .Provenance "linux/amd64").SLSA }}'
```

## Risk

Low, but not zero — worth a look at the first release rather than assuming:

- Attestations add extra entries to the image manifest list, which registry UIs and some tooling display as `unknown/unknown` platforms. This is expected and normal for attested images, but it does change what the Quay tag page looks like.
- Anything that pulls by digest and enumerates manifest entries without filtering by platform could be surprised. Normal `docker pull` and Kubernetes image pulls are unaffected.
- Small increase in push size and build time.
- **Attestations are not retroactive** — only images built after this merges will carry them.

Nothing here changes the image contents, only what is published alongside it. Easy to revert by dropping the four lines.