### PR TITLE
Bump idp-wizard to 0.52

### DIFF
--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -42,7 +42,7 @@
     <keycloak-scim-server.version>1.7.0.1</keycloak-scim-server.version>
     <keycloak-themes.version>0.75</keycloak-themes.version>
     <phasetwo-admin-portal.version>0.60</phasetwo-admin-portal.version>
-    <phasetwo-idp-wizard.version>0.49</phasetwo-idp-wizard.version>
+    <phasetwo-idp-wizard.version>0.52</phasetwo-idp-wizard.version>
     <auto-service.version>1.1.1</auto-service.version>
     <guava.version>33.0.0-jre</guava.version>
     <lombok.version>1.18.46</lombok.version>


### PR DESCRIPTION
Bumps `phasetwo-idp-wizard.version` in `libs/pom.xml` from **0.49** to **0.52**. That property is the only place the version appears — `libs/bundle/pom.xml` consumes it, and the READMEs and `ComponentDigest.java` reference the component without pinning a version.

## Why

Opening the wizard through an organization portal link has been failing with

```
400 Invalid parameter: redirect_uri
```

on every realm running Keycloak **26.6.5 or newer**. 26.6.5 added `FORBIDDEN_OIDC_PARAMS` to `RedirectUtils` (commit `1f58a4b79a`, backport of keycloak#49959), which rejects any `redirect_uri` containing an OIDC response parameter — `code`, `state`, `session_state`, `iss` and friends. The check runs before redirect-URI matching, so client configuration is irrelevant and there is no config knob.

The portal link delivers its authorization response in the **query** string, while keycloak-js reads the **fragment**. The response was therefore never consumed, and keycloak-js's retry defaulted `redirect_uri` to `window.location.href` — still carrying those parameters. Fixed in idp-wizard #278 and #279.

This flow worked on 26.6.4 and earlier, so it has been breaking for customers as their clusters get upgraded.

## Also in the 0.49 → 0.52 range

- Connection protocol page centering, left-aligned since 0.37 (idp-wizard #279)
- Local `docker compose up --build` fixed (idp-wizard #279)
- axios 1.15.0 → 1.18.0 (idp-wizard #277)

## Verification

The fix was verified end to end before release, against a local Keycloak **26.6.6** running this JAR, driving the real portal-link flow (`POST /orgs/{id}/portal-link` → action token → wizard):

```
1  login-actions/action-token          302
2  login-actions/required-action       302  ==> /wizard?session_state=…&iss=…&code=…
11 openid-connect/auth                 302  ← one only, redirect_uri clean
12 /wizard                             200
20 POST openid-connect/token           200  ← code redeemed
```

One authorization request, one token exchange, no loop. Centering confirmed visually on the same build.

## Note on 0.50 and 0.51 — do not pin either

**0.51 fixed the 400 but introduced an infinite login loop.** It cleared the OIDC parameters from the fragment as well as the query, and since the fragment is keycloak-js's callback channel under `response_mode=fragment`, the authorization response was deleted before it could be read. A captured HAR showed 23 authorization requests and zero requests to the token endpoint. That is a worse failure than the error page it replaced — the 400 at least stopped, whereas the loop hammers the authorization endpoint.

**0.52 is the first release carrying both the original fix and the loop fix.**

## Before merging

`0.52` was released minutes ago and had not yet appeared on Maven Central when this PR was opened — the release workflow succeeded, but `maven-metadata.xml` still listed `0.51` as latest. Central sync usually takes 10–30 minutes. If CI fails to resolve the dependency, re-run it rather than treating it as a real failure, and confirm with:

```
curl -sI https://repo1.maven.org/maven2/io/phasetwo/phasetwo-idp-wizard/0.52/phasetwo-idp-wizard-0.52.jar
```
