### PR TITLE
Surface the release build tag via the version provider's operationalInfo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           provenance: true
           build-args: |
             GIT_COMMIT=${{ env.GIT_COMMIT }}
+            BUILD_TAG=${{ env.VERSION_TAG }}
           build-contexts: |
             keycloak=${{ steps.keycloak.outputs.context-path }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,13 @@ LABEL org.opencontainers.image.title="phasetwo-keycloak" \
       org.opencontainers.image.licenses="Elastic-2.0" \
       org.opencontainers.image.vendor="Phase Two, Inc."
 
+# The full release tag (eg. 26.6.4.1788529342), surfaced at runtime via
+# PhaseTwoVersionProvider's operationalInfo. Only release.yml passes this
+# build-arg (it's the only workflow that computes VERSION_TAG); PR builds,
+# local `docker build`, and non-Docker runs keep the "untagged" default.
+ARG BUILD_TAG=untagged
+ENV BUILD_TAG=${BUILD_TAG}
+
 # Dedicated non-root identity for the running process. UID/GID 2000 avoids
 # collisions with the UID 1000 baked into many base images and lines up with
 # the article's reference numbers; overridable at build time via --build-arg

--- a/libs/internal/src/main/java/io/phasetwo/containers/stats/PhaseTwoVersionProvider.java
+++ b/libs/internal/src/main/java/io/phasetwo/containers/stats/PhaseTwoVersionProvider.java
@@ -35,6 +35,14 @@ public class PhaseTwoVersionProvider
     return Banner.getBanner();
   }
 
+  // Set as a plain runtime ENV var (not baked in at compile time via
+  // fizzed-versionizer like COMMIT/TIMESTAMP) because it's only known to CI
+  // after the image build starts (see release.yml's VERSION_TAG). Only the
+  // release pipeline passes BUILD_TAG through; PR/verify builds and any
+  // non-Docker run (local `mvn`, tests) never set it, so they report
+  // "untagged" instead of a stale or misleading version string.
+  private static final String UNTAGGED = "untagged";
+
   @Override
   public Map<String, String> getVersion() {
     Map<String, String> v = Maps.newHashMap();
@@ -42,6 +50,7 @@ public class PhaseTwoVersionProvider
     v.put("vendor", Version.getVendor());
     v.put("commit", Version.getCommit());
     v.put("timestamp", Version.getTimestamp());
+    v.put("buildTag", System.getenv().getOrDefault("BUILD_TAG", UNTAGGED));
     return v;
   }
 


### PR DESCRIPTION
## Summary
- Adds a `buildTag` field (eg. `26.6.4.1788529342`) to `PhaseTwoVersionProvider`, queryable via `/admin/serverinfo` under `providers.versionProvider.phasetwo-version.operationalInfo`.
- Read from a `BUILD_TAG` runtime env var (default `untagged`), set in the final Docker stage from a new `BUILD_TAG` build-arg.
- Only `release.yml` passes the real value in (from its existing `VERSION_TAG` computation). PR/verify builds and any non-Docker run (local `mvn`, tests) keep the `untagged` default.

Closes #175

## Test plan
- [ ] `mvn -pl internal -am compile` (requires Keycloak 26.6.6 built from source per `scripts/build-keycloak.sh`, not verified in this environment)
- [ ] Build the image locally and confirm `BUILD_TAG` shows up in `docker inspect` env and in `/admin/serverinfo`'s `operationalInfo` for `phasetwo-version`
- [ ] Confirm a plain `docker build .` (no build-arg) reports `untagged`