### PR TITLE
Fix podman compatibility for local Dockerfile/compose build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ FROM scratch AS keycloak
 # (essential for iterating on a SNAPSHOT: `cp -rn` would leave a stale
 # previous build of the SNAPSHOT in the cache forever).
 # ---------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-21 AS libs-builder
+FROM --platform=$BUILDPLATFORM docker.io/library/maven:3.9-eclipse-temurin-21 AS libs-builder
 
 # Git commit SHA injected at build time. The buildnumber-maven-plugin inside
 # libs/internal/pom.xml normally reads this from .git, but .git is not
@@ -118,7 +118,7 @@ RUN --mount=type=cache,target=/root/.m2,sharing=locked \
 # be built, and drops the UBI9-micro intermediary from the critical path — the
 # runtime image (stage 3) is Wolfi and never used anything else from it.
 # ---------------------------------------------------------------------------
-FROM eclipse-temurin:21-jdk AS keycloak-builder
+FROM docker.io/library/eclipse-temurin:21-jdk AS keycloak-builder
 
 # `kc.sh build` needs a JDK, tar and bash; the base image supplies all three.
 RUN --mount=type=bind,from=keycloak,target=/kc,readonly \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   cockroach:
-    image: cockroachdb/cockroach:v23.2.23
+    image: docker.io/cockroachdb/cockroach:v23.2.23
     volumes:
       - cockroach_data:/cockroach/cockroach-data
     command: start-single-node --insecure
@@ -52,13 +52,13 @@ services:
       KC_DB_USERNAME: root
       KC_FEATURES: persistent-user-sessions
       KC_FEATURES_DISABLED: organization
-      KC_HEALTH_ENABLED: true
+      KC_HEALTH_ENABLED: 'true'
       KC_HOSTNAME_STRICT: 'false'
       KC_HTTP_ENABLED: 'true'
       KC_HTTP_MANAGEMENT_PORT: 9000
       KC_ISPN_DB_VENDOR: cockroachdb
       KC_LOG_LEVEL: "INFO,io.phasetwo:DEBUG,org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory:DEBUG,fi.metatavu.keycloak.scim.server:DEBUG"
-      KC_METRICS_ENABLED: true
+      KC_METRICS_ENABLED: 'true'
       KC_PROXY_HEADERS: 'xforwarded'
       KC_SPI_EVENTS_STORE_PROVIDER: ext-event-mdc-logger-store
       KC_SPI_EVENTS_STORE_EXT_EVENT_MDC_LOGGER_STORE_USE_JPA: 'true'
@@ -73,7 +73,7 @@ services:
       - cockroach
     entrypoint: /opt/keycloak/bin/kc.sh --verbose start --spi-email-template-provider=freemarker-plus-mustache --spi-email-template-freemarker-plus-mustache-enabled=true --spi-theme-cache-themes=false
   caddy:
-    image: caddy:2-alpine
+    image: docker.io/library/caddy:2-alpine
     restart: unless-stopped
     command: caddy reverse-proxy --from ${CADDY_FROM:-:80} --to http://keycloak:8080
     # Caddy is opt-in via `docker compose --profile public-proxy up` so that


### PR DESCRIPTION
## Summary
- Fully qualify every image reference in `Dockerfile` and `docker-compose.yml` (`maven`, `eclipse-temurin`, `cockroachdb/cockroach`, `caddy`) with an explicit registry host (`docker.io/...`).
- Quote `KC_HEALTH_ENABLED` and `KC_METRICS_ENABLED` as strings in `docker-compose.yml`.

## Why
`podman`/`podman-compose` has no default `unqualified-search-registries`, unlike Docker. Short image references (`maven:3.9-eclipse-temurin-21`, `eclipse-temurin:21-jdk`, `cockroachdb/cockroach:...`, `caddy:...`) fail with:
```
short-name "eclipse-temurin:21-jdk" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```
`cockroachdb/cockroach` and `caddy` happened to work locally only because those images were already cached from earlier pulls — on a clean podman setup they'd hit the same error (verified by dry-running a pull of a nonexistent tag for each, which fails at short-name resolution before ever reaching the registry).

Separately, `podman-compose` (PyYAML-based) parses the unquoted `true` in `KC_HEALTH_ENABLED: true` / `KC_METRICS_ENABLED: true` as a Python bool and stringifies it as `"True"` when injecting it into the container environment, which Keycloak's Quarkus config rejects:
```
Invalid value for option 'KC_METRICS_ENABLED': True. Expected values are: true, false
```
Quoting both as YAML strings fixes this without changing behavior under `docker compose`.

## Test plan
- [x] `podman-compose -f docker-compose.yml build` — succeeds (built against Keycloak 26.6.6 staged via `scripts/build-keycloak.sh`)
- [x] `podman-compose -f docker-compose.yml up -d cockroach keycloak` — Keycloak starts cleanly, no short-name or boolean-parsing errors
- [x] `docker compose` semantics unaffected — fully-qualified `docker.io/...` refs and quoted `'true'` strings are no-ops for Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)